### PR TITLE
Add/update various Zope 2 related build jobs.

### DIFF
--- a/rackspace.ini
+++ b/rackspace.ini
@@ -298,8 +298,9 @@ repotype = git
 package = AccessControl
 minVersion = 3.0.7
 maxVersion =
-excludeVersions = 2.13.5 2.13.6 4.0a1 4.0a2 4.0a3 4.0a4
-targets = py27_32 py27_64
+excludeVersions = 2.13.5 2.13.6 4.0a1 4.0a2 4.0a3 4.0a4 4.0a5
+targets = py27_32 py27_32X py27_64 py27_64X
+          py34_32 py34_32X py34_64 py34_64X
 repotype = git
 
 [Acquisition_git]
@@ -307,7 +308,8 @@ package = Acquisition
 minVersion = 4.0.0
 maxVersion =
 excludeVersions = 2.11.0b1 2.12.0a1 4.0 4.0a1
-targets = py27_32 py27_64
+targets = py27_32 py27_32X py27_64 py27_64X
+          py34_32 py34_32X py34_64 py34_64X
 repotype = git
 
 [ExtensionClass_git]
@@ -316,20 +318,37 @@ minVersion = 4.1
 maxVersion =
 # 4.2.0 4.2.1: fails C module compilation
 excludeVersions = 2.11.0b1 4.0a1 4.2.0 4.2.1
-targets = py27_32 py27_64
+targets = py27_32 py27_32X py27_64 py27_64X
+          py34_32 py34_32X py34_64 py34_64X
 repotype = git
 
 [Missing_git]
 package = Missing
 minVersion = 3.0
-maxVersion =
+maxVersion = 3.2.99
 targets = py27_32 py27_64
+repotype = git
+
+[MultiMapping_git]
+package = MultiMapping
+minVersion = 2.13.0
+maxVersion = 3.1.99
+targets = py27_32 py27_64
+repotype = git
+
+[Persistence_git]
+package = Persistence
+minVersion = 2.99.999
+maxVersion =
+excludeVersions = 3.0a1
+targets = py27_32 py27_32X py27_64 py27_64X
+          py34_32 py34_32X py34_64 py34_64X
 repotype = git
 
 [Record_git]
 package = Record
 minVersion = 3.0
-maxVersion =
+maxVersion = 3.2.99
 targets = py27_32 py27_64
 repotype = git
 
@@ -340,16 +359,6 @@ maxVersion = 2.12.99
 targets = py27_32 py27_64
 repotype = git
 repourl = https://github.com/zopefoundation/Zope.git
-
-# recent versions don't have binaries
-# [Zope2_213_git]
-# package = Zope2
-# minVersion = 2.13.22
-# maxVersion =
-# targets = py27_32 py27_64
-# excludeVersions = 2.13.22 2.13.23 2.13.24 2.13.25 4.0a1 4.0a2
-# repotype = git
-# repourl = https://github.com/zopefoundation/Zope.git
 
 [lxml]
 package = lxml


### PR DESCRIPTION
A good number of them now have Python 2/3 compatible C extensions.

Some of those have been dropped in newer versions, hence the maxVersion restrictions.

The packages generally support Python 2.7, 3.4, 3.5 and 3.6. Support for 3.2 and 3.3 is no more for these :)